### PR TITLE
feat: web comic libraryをAsterionへ配備

### DIFF
--- a/cloudflared/overlays/production/cloudflared-config.yaml
+++ b/cloudflared/overlays/production/cloudflared-config.yaml
@@ -11,6 +11,11 @@ data:
     metrics: 0.0.0.0:2000
     no-autoupdate: true
     ingress:
+    - hostname: comic.cp20.dev
+      path: ^/api/.*
+      service: http://api.web-comic-library.svc.cluster.local:3001
+    - hostname: comic.cp20.dev
+      service: http://web.web-comic-library.svc.cluster.local:3000
     - hostname: traqing.cp20.dev
       service: http://traq-ing-client.traq-ing.svc.cluster.local:80
     - hostname: cd.cp20.dev

--- a/postgresql/base/kustomization.yaml
+++ b/postgresql/base/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
 generators:
   - ksops.yaml
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
   - name: postgresql-config
     namespace: postgresql

--- a/web-comic-library/base/deployments.yaml
+++ b/web-comic-library/base/deployments.yaml
@@ -1,0 +1,178 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: web-comic-library
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: web
+          image: ghcr.io/cp-20/web-comic-library-web:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: web-comic-library
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          image: ghcr.io/cp-20/web-comic-library-api:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: web-comic-library-database
+                  key: password
+            - name: DATABASE_URL
+              value: postgres://web_comic_library:$(DATABASE_PASSWORD)@postgresql-headless.postgresql.svc.cluster.local:5432/web_comic_library
+          ports:
+            - name: http
+              containerPort: 3001
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+          resources:
+            requests:
+              cpu: 125m
+              memory: 128Mi
+            limits:
+              cpu: 125m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: web-comic-library
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/cp-20/web-comic-library-worker:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: web-comic-library-database
+                  key: password
+            - name: DATABASE_URL
+              value: postgres://web_comic_library:$(DATABASE_PASSWORD)@postgresql-headless.postgresql.svc.cluster.local:5432/web_comic_library
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/web-comic-library/base/jobs.yaml
+++ b/web-comic-library/base/jobs.yaml
@@ -1,0 +1,123 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: initialize-database
+  namespace: postgresql
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: '-2'
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: initialize-database
+          image: postgres:16
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-password
+                  key: root
+            - name: APPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: web-comic-library-database
+                  key: password
+          command:
+            - /bin/sh
+            - -ceu
+            - |
+              psql \
+                --host postgresql-headless.postgresql.svc.cluster.local \
+                --username postgres \
+                --dbname postgres \
+                --set application_password="$APPLICATION_PASSWORD" <<'SQL'
+              SELECT 'CREATE ROLE web_comic_library LOGIN'
+              WHERE NOT EXISTS (
+                SELECT 1 FROM pg_roles WHERE rolname = 'web_comic_library'
+              )
+              \gexec
+              ALTER ROLE web_comic_library PASSWORD :'application_password';
+              SELECT 'CREATE DATABASE web_comic_library OWNER web_comic_library'
+              WHERE NOT EXISTS (
+                SELECT 1 FROM pg_database WHERE datname = 'web_comic_library'
+              )
+              \gexec
+              ALTER DATABASE web_comic_library OWNER TO web_comic_library;
+              SQL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate
+  namespace: web-comic-library
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: '-1'
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: ghcr.io/cp-20/web-comic-library-worker:latest
+          command:
+            - bun
+            - run
+            - --cwd
+            - packages/db
+            - migrate
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: web-comic-library-database
+                  key: password
+            - name: DATABASE_URL
+              value: postgres://web_comic_library:$(DATABASE_PASSWORD)@postgresql-headless.postgresql.svc.cluster.local:5432/web_comic_library
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 125m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/web-comic-library/base/ksops.yaml
+++ b/web-comic-library/base/ksops.yaml
@@ -1,0 +1,12 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+
+files:
+  - ./secrets/database.yaml
+  - ./secrets/database-init.yaml

--- a/web-comic-library/base/kustomization.yaml
+++ b/web-comic-library/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployments.yaml
+  - services.yaml
+  - jobs.yaml
+
+generators:
+  - ksops.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/web-comic-library/base/secrets/database-init.yaml
+++ b/web-comic-library/base/secrets/database-init.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: web-comic-library-database
+    namespace: postgresql
+    annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/sync-wave: "-3"
+type: Opaque
+stringData:
+    password: ENC[AES256_GCM,data:XNNLjSs2J1iV+SE/0XIPkiFGj5iaip6OLHYwa2erGzQwt/5zpbXIRIaICZn7JsZdUffiBH8cg986+NdQfy/Ujw==,iv:ZDZgTf6iPh7wvCJOS8FjQWPJsJklvCF1GShnxqQ1qUw=,tag:32/pSnknklPBcVFYconZfg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ufem39g0w04wvc48n3q54ck26japsp9pe6fhykyw73q9u95xf5sqyv3u7j
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6UmlvVk43dm9hS0I4c3Zk
+            Z0YwRHhxU0VOQzV4SmwzZ0RDUWhVVFR2MGlvCmNmMEJrM2QwRWlEQ2RycTRwbEpy
+            NE5VMHBIOXNpTW1vaU5tZy93akphUnMKLS0tIGhPdmJsM0Ftc0FpazFaNDIzaVlh
+            bjZvVnhQNCtIV01uMUY5Zkx1STlhSFUKlkNzZwGFV7x/osz1eWwVU3uwejDSuyKl
+            J1f2cxT0mrvlgA6XURUKaIrwhJFs6JD0oUu+EWBlmRnnV+PXXyAsvw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-24T13:32:07Z"
+    mac: ENC[AES256_GCM,data:nQnzG6Uh0nCvwQTN6Yx2mdCSiuyAE4mEtq6HigVk5Wr7y7WnGlOZVKXMt0zLaF4v1tCCUXbLhJmK3joeFwa4D4RvxsAeylOrbyewv8FXSHyHdoZ1v6OKP43F0BmzZ9ytukY3H3cVa5xj1sDgGsQayakJNqQxmbJ2lTaBY4A8gzI=,iv:WNs0WTzEB03lZYk5xucNNi0i9erFGZ0anwfCqUI3bzg=,tag:bP/EXiE1eiKz3HNwOZPYNw==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.1

--- a/web-comic-library/base/secrets/database.yaml
+++ b/web-comic-library/base/secrets/database.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: web-comic-library-database
+    namespace: web-comic-library
+    annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/sync-wave: "-3"
+type: Opaque
+stringData:
+    password: ENC[AES256_GCM,data:nRyl+82gXa9t008Uu8L6IxVWkK/fzBvEvlfN2G0eNrP15CofIapoOWlYJ3grfMHuvVMhInvNMIBxHglD2KU9nQ==,iv:EmMnTVDrOVuYJ4jpz6oi+0hh6Rt9/N1XEhIZ19gA7is=,tag:GCxE3VToWbqVQ0DRemBtgA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ufem39g0w04wvc48n3q54ck26japsp9pe6fhykyw73q9u95xf5sqyv3u7j
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3NENFdnVYWXNIQzY3ZzFP
+            NFhXQ3IvaldwZGM2ZW5lRTlJd21uQVlacWwwClVQMFJ2cU1MbmJFTmcweExpc08y
+            RWsyOEQ1UDFEbDFyTUdreHFZODU0SHMKLS0tIFBCWGNkeE5JbEJqUVhncVRvR2NG
+            eVdzQnMvcWhQNXFtMCtjVmh1aHZSaDAKLX0aodtcqAG58EGvEmb41RwW+px4xaE+
+            M3Uyc8E1IllAHdkuPzkOMJHGl7BFBOcgyD5DKRrq6BImQVFJMCDOzQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-24T13:32:07Z"
+    mac: ENC[AES256_GCM,data:Q7+68nZrFBIN6ZD7crlc4XdnYUqUryi4lXbLwpdJyntGIzOzvhXpQDtBKSYib/VOqu2E1Rr29jLBJaZ7ROLRhufPenXnZmpg8sxnt1us/JbKNrCL8et7coT4mw0rxEqbsZ4wttpbA4WuD/XRerRbqVTLTN3I4Hk9b2h6Qlo7zDU=,iv:CJz4xVgDrm//SCkoxp/oVLhRzIEAjX3mKyugdffhrg0=,tag:3ezX1E/o1uX/fKu+pYnaGg==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.1

--- a/web-comic-library/base/services.yaml
+++ b/web-comic-library/base/services.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: web-comic-library
+spec:
+  type: ClusterIP
+  selector:
+    app: web
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: web-comic-library
+spec:
+  type: ClusterIP
+  selector:
+    app: api
+  ports:
+    - name: http
+      port: 3001
+      targetPort: http

--- a/web-comic-library/overlays/local/kustomization.yaml
+++ b/web-comic-library/overlays/local/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: ghcr.io/cp-20/web-comic-library-web
+    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd
+  - name: ghcr.io/cp-20/web-comic-library-api
+    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd
+  - name: ghcr.io/cp-20/web-comic-library-worker
+    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd

--- a/web-comic-library/overlays/production/kustomization.yaml
+++ b/web-comic-library/overlays/production/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: ghcr.io/cp-20/web-comic-library-web
+    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd
+  - name: ghcr.io/cp-20/web-comic-library-api
+    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd
+  - name: ghcr.io/cp-20/web-comic-library-worker
+    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd


### PR DESCRIPTION
## 変更

- web-comic-libraryのbase、local overlay、production overlayを追加
- Web、API、workerをClusterIPと1 replicaで構成
- database role作成とmigrationをPreSync hookで順序付け
- database passwordを既存age recipientでSOPS暗号化
- production cloudflaredへcomic.cp20.devのAPI/Web routeを追加
- PostgreSQL Secret名を安定化してDB初期化Jobから参照

## 検証

- repository標準の全overlay build
- kubeconform
- SOPS復号後の2 Secretのpassword一致
- production overlayのAsterion server-side dry run
- GHCR SHA tagの匿名pull

Secret平文はGit履歴とmanifestに含まれません。