### PR TITLE
fix: cloudflared設定変更時にrolloutする

### DIFF
--- a/cloudflared/overlays/local/cloudflared-config.yaml
+++ b/cloudflared/overlays/local/cloudflared-config.yaml
@@ -1,15 +1,7 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cloudflared
-  namespace: cloudflared
-
-# ローカル環境では cloudflared によるルーティングは利用しない
-data:
-  config.yaml: |
-    tunnel: asterion
-    credentials-file: /etc/cloudflared/creds/credentials.json
-    metrics: 0.0.0.0:2000
-    no-autoupdate: true
-    ingress:
-    - service: http_status:404
+# ローカル環境ではcloudflaredによるroutingを利用しない。
+tunnel: asterion
+credentials-file: /etc/cloudflared/creds/credentials.json
+metrics: 0.0.0.0:2000
+no-autoupdate: true
+ingress:
+  - service: http_status:404

--- a/cloudflared/overlays/local/kustomization.yaml
+++ b/cloudflared/overlays/local/kustomization.yaml
@@ -1,3 +1,8 @@
 resources:
   - ../../base
-  - cloudflared-config.yaml
+
+configMapGenerator:
+  - name: cloudflared
+    namespace: cloudflared
+    files:
+      - config.yaml=cloudflared-config.yaml

--- a/cloudflared/overlays/production/cloudflared-config.yaml
+++ b/cloudflared/overlays/production/cloudflared-config.yaml
@@ -1,25 +1,17 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cloudflared
-  namespace: cloudflared
-
-data:
-  config.yaml: |
-    tunnel: asterion
-    credentials-file: /etc/cloudflared/creds/credentials.json
-    metrics: 0.0.0.0:2000
-    no-autoupdate: true
-    ingress:
-    - hostname: comic.cp20.dev
-      path: ^/api/.*
-      service: http://api.web-comic-library.svc.cluster.local:3001
-    - hostname: comic.cp20.dev
-      service: http://web.web-comic-library.svc.cluster.local:3000
-    - hostname: traqing.cp20.dev
-      service: http://traq-ing-client.traq-ing.svc.cluster.local:80
-    - hostname: cd.cp20.dev
-      service: http://argocd-server.argocd.svc.cluster.local:443
-    - hostname: adminer.cp20.dev
-      service: http://adminer.postgresql.svc.cluster.local:8080
-    - service: http_status:404
+tunnel: asterion
+credentials-file: /etc/cloudflared/creds/credentials.json
+metrics: 0.0.0.0:2000
+no-autoupdate: true
+ingress:
+  - hostname: comic.cp20.dev
+    path: ^/api/.*
+    service: http://api.web-comic-library.svc.cluster.local:3001
+  - hostname: comic.cp20.dev
+    service: http://web.web-comic-library.svc.cluster.local:3000
+  - hostname: traqing.cp20.dev
+    service: http://traq-ing-client.traq-ing.svc.cluster.local:80
+  - hostname: cd.cp20.dev
+    service: http://argocd-server.argocd.svc.cluster.local:443
+  - hostname: adminer.cp20.dev
+    service: http://adminer.postgresql.svc.cluster.local:8080
+  - service: http_status:404

--- a/cloudflared/overlays/production/kustomization.yaml
+++ b/cloudflared/overlays/production/kustomization.yaml
@@ -1,3 +1,8 @@
 resources:
   - ../../base
-  - cloudflared-config.yaml
+
+configMapGenerator:
+  - name: cloudflared
+    namespace: cloudflared
+    files:
+      - config.yaml=cloudflared-config.yaml


### PR DESCRIPTION
## 変更

cloudflaredのlocal/production ConfigMapをKustomize configMapGeneratorへ変更し、内容hashを名前へ付与しました。Deploymentのvolume参照もKustomizeが同じ名前へ更新するため、設定変更時にPod templateが変わりrolloutします。

## 検証

- 全overlay build
- kubeconform
- local/productionでConfigMap名とDeployment参照が一致
- ConfigMap名がhash付き
- Asterion server-side dry run

Closes #128