### PR TITLE
Add backup and observability operations

### DIFF
--- a/cloudflared/base/kustomization.yaml
+++ b/cloudflared/base/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - cloudflared.yaml
+  - metrics-service.yaml

--- a/cloudflared/base/metrics-service.yaml
+++ b/cloudflared/base/metrics-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloudflared-metrics
+  namespace: cloudflared
+spec:
+  type: ClusterIP
+  selector:
+    app: cloudflared
+  ports:
+    - name: metrics
+      port: 2000
+      targetPort: 2000

--- a/monitoring/base/config/alertmanager.yml
+++ b/monitoring/base/config/alertmanager.yml
@@ -1,0 +1,19 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: discord
+  group_by:
+    - alertname
+    - namespace
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: discord
+    discord_configs:
+      - webhook_url_file: /etc/alertmanager/secrets/discord-webhook
+        send_resolved: true
+        title: '{{ .Status | toUpper }}: {{ .CommonLabels.alertname }}'
+        message: '{{ range .Alerts }}{{ .Annotations.summary }}{{ "\n" }}{{ end }}'

--- a/monitoring/base/config/alerts.yml
+++ b/monitoring/base/config/alerts.yml
@@ -1,0 +1,83 @@
+groups:
+  - name: asterion
+    rules:
+      - alert: ScrapeTargetDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $labels.job }} is unreachable'
+      - alert: NodeMemoryLow
+        expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Asterion available memory is below 10%'
+      - alert: NodeCpuHigh
+        expr: 1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Asterion CPU usage is above 90%'
+      - alert: NodeDiskLow
+        expr: node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",mountpoint="/"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay",mountpoint="/"} < 0.1
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Asterion root disk available space is below 10%'
+      - alert: PersistentVolumeClaimNotBound
+        expr: kube_persistentvolumeclaim_status_phase{phase!="Bound"} == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is not Bound'
+      - alert: PodRestarted
+        expr: increase(kube_pod_container_status_restarts_total[10m]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Pod container {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} restarted'
+      - alert: ArgoCdOutOfSync
+        expr: argocd_app_info{sync_status!="Synced"} == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Argo CD application {{ $labels.name }} is {{ $labels.sync_status }}'
+      - alert: ArgoCdUnhealthy
+        expr: argocd_app_info{health_status!~"Healthy|Progressing"} == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Argo CD application {{ $labels.name }} health is {{ $labels.health_status }}'
+      - alert: JobQueueOverdue
+        expr: web_comic_library_jobs_overdue > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Web Comic Library has jobs overdue by at least ten minutes'
+      - alert: ConnectorConsecutiveFailures
+        expr: web_comic_library_connector_consecutive_failures >= 3
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Connector has failed at least three times consecutively'
+      - alert: NotificationDeliveryFailed
+        expr: increase(web_comic_library_notification_failures_total[10m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: 'A notification delivery failed'
+      - alert: BackupJobFailed
+        expr: kube_job_status_failed{job_name=~"logical-backup.*|web-comic-library-base-backup.*"} > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Backup job {{ $labels.namespace }}/{{ $labels.job_name }} failed'

--- a/monitoring/base/config/prometheus.yml
+++ b/monitoring/base/config/prometheus.yml
@@ -1,0 +1,44 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    cluster: asterion
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager.monitoring.svc.cluster.local:9093
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090
+  - job_name: node
+    static_configs:
+      - targets:
+          - node-exporter.monitoring.svc.cluster.local:9100
+  - job_name: kube-state-metrics
+    static_configs:
+      - targets:
+          - kube-state-metrics.monitoring.svc.cluster.local:8080
+  - job_name: web-comic-library-api
+    static_configs:
+      - targets:
+          - api.web-comic-library.svc.cluster.local:3001
+  - job_name: web-comic-library-worker
+    static_configs:
+      - targets:
+          - worker-metrics.web-comic-library.svc.cluster.local:3002
+  - job_name: cloudflared
+    static_configs:
+      - targets:
+          - cloudflared-metrics.cloudflared.svc.cluster.local:2000
+  - job_name: argocd
+    static_configs:
+      - targets:
+          - argocd-metrics.argocd.svc.cluster.local:8082

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rbac.yaml
+  - storage.yaml
+  - workloads.yaml
+  - services.yaml
+
+configMapGenerator:
+  - name: prometheus-config
+    namespace: monitoring
+    files:
+      - prometheus.yml=config/prometheus.yml
+      - alerts.yml=config/alerts.yml
+  - name: alertmanager-config
+    namespace: monitoring
+    files:
+      - alertmanager.yml=config/alertmanager.yml

--- a/monitoring/base/rbac.yaml
+++ b/monitoring/base/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitoring-kube-state-metrics
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+      - persistentvolumeclaims
+      - pods
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitoring-kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitoring-kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: monitoring

--- a/monitoring/base/services.yaml
+++ b/monitoring/base/services.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  namespace: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app: alertmanager
+  ports:
+    - name: http
+      port: 9093
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app: kube-state-metrics
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  namespace: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app: node-exporter
+  ports:
+    - name: metrics
+      port: 9100
+      targetPort: metrics

--- a/monitoring/base/storage.yaml
+++ b/monitoring/base/storage.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi

--- a/monitoring/base/workloads.yaml
+++ b/monitoring/base/workloads.yaml
@@ -1,0 +1,266 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: prometheus
+          image: quay.io/prometheus/prometheus:v3.13.1
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=8d
+            - --storage.tsdb.retention.size=4GB
+          ports:
+            - name: http
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: prometheus-data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alertmanager
+  template:
+    metadata:
+      labels:
+        app: alertmanager
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: alertmanager
+          image: quay.io/prometheus/alertmanager:v0.33.1
+          args:
+            - --config.file=/etc/alertmanager/alertmanager.yml
+            - --storage.path=/alertmanager
+          ports:
+            - name: http
+              containerPort: 9093
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alertmanager
+              readOnly: true
+            - name: data
+              mountPath: /alertmanager
+            - name: secrets
+              mountPath: /etc/alertmanager/secrets
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: alertmanager-config
+        - name: data
+          emptyDir: {}
+        - name: secrets
+          secret:
+            secretName: monitoring-alerts
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1
+          args:
+            - --resources=cronjobs,jobs,nodes,persistentvolumeclaims,pods
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: telemetry
+              containerPort: 8081
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: telemetry
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      automountServiceAccountToken: false
+      hostNetwork: true
+      hostPID: true
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.12.1
+          args:
+            - --path.procfs=/host/proc
+            - --path.rootfs=/host/root
+            - --path.sysfs=/host/sys
+            - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+          ports:
+            - name: metrics
+              containerPort: 9100
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              readOnly: true
+              mountPropagation: HostToContainer
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: root
+          hostPath:
+            path: /
+        - name: sys
+          hostPath:
+            path: /sys

--- a/monitoring/overlays/local/kustomization.yaml
+++ b/monitoring/overlays/local/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+secretGenerator:
+  - name: monitoring-alerts
+    namespace: monitoring
+    literals:
+      - discord-webhook=https://discord.invalid/local-only

--- a/monitoring/overlays/production/ksops.yaml
+++ b/monitoring/overlays/production/ksops.yaml
@@ -1,0 +1,11 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: production-ksops
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+
+files:
+  - ./secrets/alerts.yaml

--- a/monitoring/overlays/production/kustomization.yaml
+++ b/monitoring/overlays/production/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+generators:
+  - ksops.yaml

--- a/monitoring/overlays/production/secrets/alerts.yaml
+++ b/monitoring/overlays/production/secrets/alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: monitoring-alerts
+    namespace: monitoring
+type: Opaque
+stringData:
+    discord-webhook: ENC[AES256_GCM,data:xpppBnp++c5IjjdB2++L9bSbA3PlQQ6ULz4xJv98vVb6ZIhXgDUVTKyK+0sVGVfcd2pGGkCZtD0IWivG40+1a6BtDscP4NkOUfxCowqX+Ljl7reziDp8/Cbek6GRiGp+cAxmmSylNFh8M8py/5wfEXxH9DPw1/kWeA==,iv:V7gvqQSU643IXCeDah3G2Zxayxr3MWW73TOSmnZaEsw=,tag:uAKlW6wa6C0HYnjE5Fc5Jg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ufem39g0w04wvc48n3q54ck26japsp9pe6fhykyw73q9u95xf5sqyv3u7j
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvK0ZES1hoeVpnY3cxK0pC
+            eW05Y1BNdlZGNk1jdlJldm5IOTVwZkdaN3hvCnUzZllkSm14MDZTd3pzOFd6N25M
+            aHJ6V0ZHeG1FU2FjTE1FMVlUcWI1a00KLS0tIEk1SFlkcXV6OXNiNWpGWTF5UGdl
+            NkZhMUdoUHd1VWQ2Q2dhb3JRc2NWeDQKEvJnsRDWl4NJ5w+R3+PTrC/ZgGqqFMr9
+            Nqt03pwvpIDC2jmPkDZfTFkBIohyTlnvx/h12GOyToTrz/78Nlfqlw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-24T16:00:45Z"
+    mac: ENC[AES256_GCM,data:K2QnwqEit0VM3tl0JMfkHmxzCjFf677+v8AHfz1U2L/BYWDBpDXOVwrbcMNxnAWWy7M69kSYDW1shEs15A+o5VmGrUeiK2/vQ3mQax3SEFWPR32DJ9fnH7WjtCkzCIHip4Y8h9YLnnlt9Kmvod5uSGrtMChl+/dL1h9HzDgbmTE=,iv:hpvoocV+nIppuFjXND9zHMKnpJR44+oDkgvu8eKWwoY=,tag:4EaWarMleo5pShrxM1UAeg==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.1

--- a/postgresql/overlays/production/backup-patch.yaml
+++ b/postgresql/overlays/production/backup-patch.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql
+  namespace: postgresql
+spec:
+  template:
+    spec:
+      containers:
+        - name: postgresql
+          image: ghcr.io/cp-20/web-comic-library-database:latest
+          command:
+            - postgres
+            - -c
+            - config_file=/etc/postgresql/postgresql.conf
+            - -c
+            - hba_file=/etc/postgresql/pg_hba.conf
+            - -c
+            - archive_mode=on
+            - -c
+            - archive_timeout=900s
+            - -c
+            - archive_command=/usr/local/bin/wal-g wal-push %p
+          envFrom:
+            - secretRef:
+                name: web-comic-library-backup
+          env:
+            - name: AWS_ENDPOINT
+              value: https://a43ad580a36eae6c78e37ef19e4580c3.r2.cloudflarestorage.com
+            - name: AWS_REGION
+              value: auto
+            - name: AWS_S3_FORCE_PATH_STYLE
+              value: 'true'
+            - name: WALG_COMPRESSION_METHOD
+              value: lz4
+            - name: WALG_LIBSODIUM_KEY_TRANSFORM
+              value: base64
+            - name: WALG_PREVENT_WAL_OVERWRITE
+              value: 'true'
+            - name: WALG_S3_PREFIX
+              value: s3://cp20-web-comic-library-backups/postgresql/16
+          volumeMounts:
+            - name: postgresql-config
+              mountPath: /etc/postgresql/pg_hba.conf
+              subPath: pg_hba.conf

--- a/postgresql/overlays/production/base-backup-cronjob.yaml
+++ b/postgresql/overlays/production/base-backup-cronjob.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: web-comic-library-base-backup
+  namespace: postgresql
+  labels:
+    app.kubernetes.io/part-of: web-comic-library
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  schedule: '0 3 * * 0'
+  successfulJobsHistoryLimit: 1
+  timeZone: Asia/Tokyo
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: web-comic-library
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          securityContext:
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: backup
+              image: ghcr.io/cp-20/web-comic-library-database:latest
+              command:
+                - /bin/sh
+                - -ceu
+                - |
+                  wal-g backup-push
+                  wal-g delete retain FULL 5 --use-sentinel-time --confirm
+              envFrom:
+                - secretRef:
+                    name: web-comic-library-backup
+              env:
+                - name: AWS_ENDPOINT
+                  value: https://a43ad580a36eae6c78e37ef19e4580c3.r2.cloudflarestorage.com
+                - name: AWS_REGION
+                  value: auto
+                - name: AWS_S3_FORCE_PATH_STYLE
+                  value: 'true'
+                - name: PGDATABASE
+                  value: postgres
+                - name: PGHOST
+                  value: postgresql-headless.postgresql.svc.cluster.local
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql-password
+                      key: root
+                - name: PGUSER
+                  value: postgres
+                - name: WALG_COMPRESSION_METHOD
+                  value: lz4
+                - name: WALG_LIBSODIUM_KEY_TRANSFORM
+                  value: base64
+                - name: WALG_PREVENT_WAL_OVERWRITE
+                  value: 'true'
+                - name: WALG_S3_PREFIX
+                  value: s3://cp20-web-comic-library-backups/postgresql/16
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/postgresql/overlays/production/config/pg_hba.conf
+++ b/postgresql/overlays/production/config/pg_hba.conf
@@ -1,0 +1,8 @@
+local all all trust
+host all all 127.0.0.1/32 trust
+host all all ::1/128 trust
+local replication all trust
+host replication all 127.0.0.1/32 trust
+host replication all ::1/128 trust
+host replication postgres 10.42.0.0/16 scram-sha-256
+host all all all scram-sha-256

--- a/postgresql/overlays/production/ksops.yaml
+++ b/postgresql/overlays/production/ksops.yaml
@@ -1,0 +1,11 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: production-ksops
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+
+files:
+  - ./secrets/web-comic-library-backup.yaml

--- a/postgresql/overlays/production/kustomization.yaml
+++ b/postgresql/overlays/production/kustomization.yaml
@@ -1,2 +1,20 @@
 resources:
   - ../../base
+  - base-backup-cronjob.yaml
+
+generators:
+  - ksops.yaml
+
+configMapGenerator:
+  - name: postgresql-config
+    namespace: postgresql
+    behavior: merge
+    files:
+      - config/pg_hba.conf
+
+patches:
+  - path: backup-patch.yaml
+
+images:
+  - name: ghcr.io/cp-20/web-comic-library-database
+    newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a

--- a/postgresql/overlays/production/secrets/web-comic-library-backup.yaml
+++ b/postgresql/overlays/production/secrets/web-comic-library-backup.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: web-comic-library-backup
+    namespace: postgresql
+type: Opaque
+stringData:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:hgK0yEmwrXNxKhhpKhwgoSbofBn2lrs1wIuXWUa+neQ=,iv:v0R2ZJRoTZU47NmSRYkpoHjwi8Uojc1LPSmaADpQFww=,tag:NMOxy14Ozl0GdraOA/Jmsw==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:QIn2k+rt519tgAbNayrfaZJFVxaHLtaLIyWPnQizY7y2le9kG+ZJ9Eb5SLHx2g877hDcmj3lLNApv+xjUKO1rw==,iv:TFFyrtjdRE807maUgR0qhSGg72LUG9BAm0EI/XmcTwI=,tag:GKuxGHnT8gZuLIzzNkZr0A==,type:str]
+    WALG_LIBSODIUM_KEY: ENC[AES256_GCM,data:EW+s50TFP2Tt1MFO/XC87Fvx54Xi/sSUFmkhhN3rxtkxq5Obgo3+GLIvqHU=,iv:yCu8wP+veC9oPmhGotT9CG58Xm6BeEDDJjLPp3Y6P88=,tag:ABCrQKjGbWA8gysiZQgEXA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ufem39g0w04wvc48n3q54ck26japsp9pe6fhykyw73q9u95xf5sqyv3u7j
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1UWpQNDljSnd2RGhqVmpB
+            WHh0QXcySDhiYzE1UFozMnFNN3VicHpUWXdFCnRob2p1N0xEaEs3Mzd1RUJnWERP
+            RGxWZ1k3QjFicmRnNEtGT3k0dloxak0KLS0tIHVZcFRvZm9VYUc1WmZJakhuOC96
+            alc4YWdybGZhanMxVGVpNjZHS0ExUGsK5sQUnwkcE6138fYaU/imFH7TZAWBwAWT
+            BBNg5udZdpndV7lIDbu/+QfNP9eR56mZF+C+oRMIlxlEnCTgIlvQaQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-24T15:34:07Z"
+    mac: ENC[AES256_GCM,data:tz+kw6bqGdE3AJesuivocBdQofLfbdCBjmfiiPtpU/1N7+Y34bWsPYIKhuvI8ayJ/rIagzMo8ZRsl5OmKo7njMjU7hHSk/JUCmSmEgefw87+8DNVHpUTzfhLBfvPyfOpB0rx8/3Si7L+E9bv7HQd3SZWsCSTpm3IcalgP0oTwgU=,iv:LGDGhZ55TkiqAKBkgRYCqDZngb+qU4wMlcxPC3I0/I4=,tag:7Ou+DtWvJpwUJZDTXwyBgA==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.1

--- a/web-comic-library/overlays/production/ksops.yaml
+++ b/web-comic-library/overlays/production/ksops.yaml
@@ -1,0 +1,11 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: production-ksops
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+
+files:
+  - ./secrets/operations.yaml

--- a/web-comic-library/overlays/production/kustomization.yaml
+++ b/web-comic-library/overlays/production/kustomization.yaml
@@ -3,11 +3,21 @@ kind: Kustomization
 
 resources:
   - ../../base
+  - logical-backup-cronjob.yaml
+  - worker-metrics-service.yaml
+
+generators:
+  - ksops.yaml
+
+patches:
+  - path: observability-patch.yaml
 
 images:
   - name: ghcr.io/cp-20/web-comic-library-web
-    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd
+    newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a
   - name: ghcr.io/cp-20/web-comic-library-api
-    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd
+    newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a
   - name: ghcr.io/cp-20/web-comic-library-worker
-    newTag: bdb85504d1de4d42e2be08355316abd25c7538bd
+    newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a
+  - name: ghcr.io/cp-20/web-comic-library-database
+    newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a

--- a/web-comic-library/overlays/production/logical-backup-cronjob.yaml
+++ b/web-comic-library/overlays/production/logical-backup-cronjob.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: logical-backup
+  namespace: web-comic-library
+  labels:
+    app.kubernetes.io/part-of: web-comic-library
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  schedule: '30 3 * * *'
+  successfulJobsHistoryLimit: 1
+  timeZone: Asia/Tokyo
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: web-comic-library
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          securityContext:
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: backup
+              image: ghcr.io/cp-20/web-comic-library-database:latest
+              command:
+                - logical-backup
+              envFrom:
+                - secretRef:
+                    name: web-comic-library-operations
+              env:
+                - name: AWS_ENDPOINT
+                  value: https://a43ad580a36eae6c78e37ef19e4580c3.r2.cloudflarestorage.com
+                - name: AWS_REGION
+                  value: auto
+                - name: AWS_S3_FORCE_PATH_STYLE
+                  value: 'true'
+                - name: PGDATABASE
+                  value: web_comic_library
+                - name: PGHOST
+                  value: postgresql-headless.postgresql.svc.cluster.local
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: web-comic-library-database
+                      key: password
+                - name: PGUSER
+                  value: web_comic_library
+                - name: WALG_COMPRESSION_METHOD
+                  value: lz4
+                - name: WALG_LIBSODIUM_KEY_TRANSFORM
+                  value: base64
+                - name: WALG_S3_PREFIX
+                  value: s3://cp20-web-comic-library-backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/web-comic-library/overlays/production/observability-patch.yaml
+++ b/web-comic-library/overlays/production/observability-patch.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: web-comic-library
+spec:
+  template:
+    spec:
+      containers:
+        - name: web
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: web-comic-library-operations
+                  key: SENTRY_DSN
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: web-comic-library
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: web-comic-library-operations
+                  key: SENTRY_DSN
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: web-comic-library
+spec:
+  template:
+    spec:
+      containers:
+        - name: worker
+          ports:
+            - name: metrics
+              containerPort: 3002
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/web-comic-library/overlays/production/secrets/operations.yaml
+++ b/web-comic-library/overlays/production/secrets/operations.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: web-comic-library-operations
+    namespace: web-comic-library
+type: Opaque
+stringData:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:zX3/uJlr/0M1ekVOigsxk75Cj40S4b+sQN1MmdcWADw=,iv:fDP77FxyklCitJMvZh5YFC9FP6HtEJsC0gPOTb8nT5k=,tag:ok4Ng9JYah48gBsWpTsjEQ==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:hFYuPll1WTu4Fk5XEIbkmEbIcj9GWKoHOojYJ0+BQt6KwnhPgQfFIPlqF1X42O1DzQWHmSFvrpc2vz14kJdOGQ==,iv:mqizO14kNBx+N00JoNTZ2n0V3CPr2hcZxldXuwqcQF8=,tag:+E6p/6O7IlN35ngHoNZJog==,type:str]
+    SENTRY_DSN: ENC[AES256_GCM,data:B+AnEjd39IIsHm5FaujnZiciBaL3iNEk1na8sDpPae/X/0gsefWxPxRhZwQ1ZI4IZHTy6l1mlDSy4nSMEdSKqPNCgWadgNtNR7OF30rRmxqGd2fmBbHzk9jzdrJziFA=,iv:OL72ywKYtFJ6IalyIOTZziZhe55By+dFvJptw7wOqcU=,tag:+DImhsq3zYqOp6djuxYj2A==,type:str]
+    WALG_LIBSODIUM_KEY: ENC[AES256_GCM,data:UOD1alFp8y8E7QYN+IOJKf3Z15nWNyFZxWTha/UJXJGehAW1iPS+ITd1+wg=,iv:OHuppfQmvW58HrFIhg4WW/7J+QSwt8Ompg9h0PunIHg=,tag:nMrq4c9NncMTjvWVqx57yA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ufem39g0w04wvc48n3q54ck26japsp9pe6fhykyw73q9u95xf5sqyv3u7j
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMR3c2K1UvNGZaVXVZeFdn
+            VnVWTnJVek5SRVFnTXhWVnNla1RFWGd1TGdvCm91U0JsVVMzV0Z0eWN4SnNXa2tm
+            R1NLNmFZUWpvUEk3WW1xZllWYWoxWUUKLS0tIFFJUXh5SjdiY2lkaUJSZjZPZXRw
+            cGRZQmwvV1JaVThZNHB2QkRUZjAyMGMKnqNWyxbdI2k2LyhrkPbcDDNETpraVZPL
+            RPCMX1PoHonJPiR5Uc0s9isnYUkeh01Ssg0amr47mgSWaJ4kjxT4XA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-24T15:25:48Z"
+    mac: ENC[AES256_GCM,data:vo8B/HHZf2xSr9cWsnvSuAHUdUAOlEhmR1/SPo9lJ0M4qBTbMW+b/kFOxlv2jxslLjQ7dYLPz9XHVJA+rX1eLXq3IcMIbVinneupC5AkNdWscq/14lszvYth6GIuX6ToN5cIYb9zPRw+tnPB/76Kg6pDrLn6CBCeUeWSHs1RDdY=,iv:99RK+tyGrElgqdPhqUezVtiqSZFxW7NsnFsaWoN1oLg=,tag:nDJ4zH6xmXGU64SROjWPmA==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.1

--- a/web-comic-library/overlays/production/worker-metrics-service.yaml
+++ b/web-comic-library/overlays/production/worker-metrics-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: worker-metrics
+  namespace: web-comic-library
+spec:
+  type: ClusterIP
+  selector:
+    app: worker
+  ports:
+    - name: metrics
+      port: 3002
+      targetPort: metrics


### PR DESCRIPTION
## Summary
- configure encrypted WAL-G physical and logical backups to Cloudflare R2
- deploy Prometheus, Alertmanager, kube-state-metrics, and node-exporter
- scrape application, cloudflared, and Argo CD metrics and alert to Discord
- inject privacy-safe Sentry configuration and pin issue #006 images

## Validation
- Prometheus config and 12 alert rules validated with promtool v3.13.1
- Alertmanager config validated with amtool v0.33.1
- production overlays validated with kubeconform (39 resources)
- Discord webhook test returned HTTP 204