### PR TITLE
Fix R2 backup runtime configuration

### DIFF
--- a/postgresql/overlays/production/backup-patch.yaml
+++ b/postgresql/overlays/production/backup-patch.yaml
@@ -31,6 +31,10 @@ spec:
               value: auto
             - name: AWS_S3_FORCE_PATH_STYLE
               value: 'true'
+            - name: S3_ENABLE_VERSIONING
+              value: disabled
+            - name: S3_MAX_RETRIES
+              value: '3'
             - name: WALG_COMPRESSION_METHOD
               value: lz4
             - name: WALG_LIBSODIUM_KEY_TRANSFORM

--- a/postgresql/overlays/production/base-backup-cronjob.yaml
+++ b/postgresql/overlays/production/base-backup-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                 - /bin/sh
                 - -ceu
                 - |
-                  wal-g backup-push
+                  wal-g backup-push /var/lib/postgresql/data
                   wal-g delete retain FULL 5 --use-sentinel-time --confirm
               envFrom:
                 - secretRef:
@@ -46,6 +46,10 @@ spec:
                   value: auto
                 - name: AWS_S3_FORCE_PATH_STYLE
                   value: 'true'
+                - name: S3_ENABLE_VERSIONING
+                  value: disabled
+                - name: S3_MAX_RETRIES
+                  value: '3'
                 - name: PGDATABASE
                   value: postgres
                 - name: PGHOST
@@ -79,8 +83,15 @@ spec:
                     - ALL
                 readOnlyRootFilesystem: true
               volumeMounts:
+                - name: postgresql-data
+                  mountPath: /var/lib/postgresql/data
+                  readOnly: true
                 - name: tmp
                   mountPath: /tmp
           volumes:
+            - name: postgresql-data
+              persistentVolumeClaim:
+                claimName: postgresql-data
+                readOnly: true
             - name: tmp
               emptyDir: {}

--- a/postgresql/overlays/production/kustomization.yaml
+++ b/postgresql/overlays/production/kustomization.yaml
@@ -17,4 +17,4 @@ patches:
 
 images:
   - name: ghcr.io/cp-20/web-comic-library-database
-    newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a
+    newTag: 226dcd23c07592570d5e01b69600d3a5fad09185

--- a/web-comic-library/overlays/production/kustomization.yaml
+++ b/web-comic-library/overlays/production/kustomization.yaml
@@ -20,4 +20,4 @@ images:
   - name: ghcr.io/cp-20/web-comic-library-worker
     newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a
   - name: ghcr.io/cp-20/web-comic-library-database
-    newTag: 457f2e9b4ff8a49e109ec098ce7f07503dd6299a
+    newTag: 226dcd23c07592570d5e01b69600d3a5fad09185

--- a/web-comic-library/overlays/production/logical-backup-cronjob.yaml
+++ b/web-comic-library/overlays/production/logical-backup-cronjob.yaml
@@ -42,6 +42,10 @@ spec:
                   value: auto
                 - name: AWS_S3_FORCE_PATH_STYLE
                   value: 'true'
+                - name: S3_ENABLE_VERSIONING
+                  value: disabled
+                - name: S3_MAX_RETRIES
+                  value: '3'
                 - name: PGDATABASE
                   value: web_comic_library
                 - name: PGHOST


### PR DESCRIPTION
## Summary
- use the CA-enabled database image from web-comic-library PR #6
- disable unsupported S3 bucket versioning checks for R2
- cap S3 retries at three
- mount the PostgreSQL PVC read-only and use WAL-G local backup mode

## Cause
- the image lacked a CA bundle, so R2 TLS verification failed
- WAL-G remote backup failed while parsing the PostgreSQL base-backup tar stream

## Validation
- PostgreSQL production overlay: 9 valid resources
- Web production overlay: 12 valid resources