### PR TITLE
fix PostgreSQL backup memory limit

### DIFF
--- a/postgresql/overlays/production/base-backup-cronjob.yaml
+++ b/postgresql/overlays/production/base-backup-cronjob.yaml
@@ -72,10 +72,10 @@ spec:
               resources:
                 requests:
                   cpu: 50m
-                  memory: 128Mi
+                  memory: 256Mi
                 limits:
                   cpu: 500m
-                  memory: 512Mi
+                  memory: 1Gi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
## 変更内容

PostgreSQL physical backup CronJobのmemory requestを128MiBから256MiB、limitを512MiBから1GiBへ変更します。

## 理由

約7.2GiBの現行clusterをWAL-Gでbackupした際、512MiB Podがtar part処理中にOOMKilledとなったためです。

## 検証

- 同じCronJob定義を256MiB / 1GiBへ上書きしたone-off Jobが5分17秒で完了
- R2の`backup-list`で新しいbase backupを確認
- Pod終了理由がCompleted
- Kustomize production overlayをrender
- kubeconform strict: 9 resources valid