### PR TITLE
remove scrape target down alert

### DIFF
--- a/monitoring/base/config/alerts.yml
+++ b/monitoring/base/config/alerts.yml
@@ -1,13 +1,6 @@
 groups:
   - name: asterion
     rules:
-      - alert: ScrapeTargetDown
-        expr: up == 0
-        for: 2m
-        labels:
-          severity: critical
-        annotations:
-          summary: '{{ $labels.job }} is unreachable'
       - alert: NodeMemoryLow
         expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.1
         for: 10m


### PR DESCRIPTION
## 変更

Prometheus の `ScrapeTargetDown`（`up == 0`）alert rule を削除します。

ノード、PVC、Argo CD、PostgreSQL backup の alert は維持します。通知ノイズを止めつつ、より具体的な障害 alert は残ります。

## 検証

- `kustomize build monitoring/overlays/local` + `kubeconform`
- `kustomize build monitoring/overlays/production` + `kubeconform`
- `git diff --check`