### PR TITLE
recreate prometheus deployment

### DIFF
--- a/monitoring/base/workloads.yaml
+++ b/monitoring/base/workloads.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: prometheus


### PR DESCRIPTION
## 変更

Prometheus Deployment の更新strategyを `RollingUpdate` から `Recreate` へ変更します。

## 原因

単一replicaの新旧Podが同じ `prometheus-data` PVCを同時利用し、新PodがTSDB lockを取得できずCrashLoopしていました。新PodがReadyにならないため旧Podもscale downされず、rolloutが永久に滞留していました。

## 影響

更新時は旧Pod終了から新Pod ReadyまでPrometheusが短時間停止します。PVCと保存済みTSDB dataは保持します。

## 検証

- local/production monitoring overlayの`kustomize build`
- local/production render結果の`kubeconform`
- production renderでPrometheusのみ`strategy.type: Recreate`を確認
- `git diff --check`